### PR TITLE
LAVA xnbd protocol support and documentation for nbd boot to lava-server

### DIFF
--- a/doc/v2/actions-deploy-to-nbd.rsti
+++ b/doc/v2/actions-deploy-to-nbd.rsti
@@ -1,0 +1,178 @@
+.. index:: deploy to nbd
+
+.. _deploy_to_nbd:
+
+to: nbd
+********
+
+Used to support NBDroot deployments, e.g. using a initrd with nbd-client
+and pivot_root. Files are downloaded to a temporary directory on the worker,
+the rootfs is shared through xnbd-server and the filenames are substituted into the
+bootloader commands specified in the device configuration or overridden in the
+job. The files to download typically include a kernel but can also include any
+file which the substitution commands need for this deployment. URL support is
+handled by the python ``requests`` module.
+
+.. include:: examples/test-jobs/standard-nbd-netboot-bbb.yaml
+     :code: yaml
+     :start-after: actions:
+     :end-before: kernel:
+
+.. _deploy_to_nbd_kernel:
+
+kernel
+======
+
+To deploy images using NBDroot, arguments will be downloaded to a configured directory.
+
+.. _deploy_to_nbd_kernel_url:
+
+url
+---
+
+Specifies the URL to download. All downloads are checksummed using ``md5sum``
+and ``sha256sum``
+
+URLs are checked during the test job validation to ensure that the file can be
+downloaded. Missing files will cause the test job to end as Incomplete.
+
+URLs **must** use one of the supported schemes, the first element of the URL.
+
+.. include:: examples/test-jobs/standard-nbd-netboot-bbb.yaml
+     :code: yaml
+     :start-after: to: nbd
+     :end-before: initrd:
+
+.. topic:: Supported schema
+
+ * ``http://``
+ * ``https://``
+ * ``file://``
+
+.. _deploy_to_nbd_dtb:
+
+dtb
+===
+
+(Device Tree Blob).
+
+.. _deploy_to_nbd_dtb_url:
+
+url
+---
+
+Specifies the URL to download. All downloads are checksummed using ``md5sum``
+and ``sha256sum``
+
+URLs are checked during the test job validation to ensure that the file can be
+downloaded. Missing files will cause the test job to end as Incomplete.
+
+URLs **must** use one of the supported schemes, the first element of the URL.
+
+.. include:: examples/test-jobs/standard-nbd-netboot-bbb.yaml
+     :code: yaml
+     :start-after: os: debian
+     :end-before: - boot
+
+.. topic:: Supported schema
+
+ * ``http://``
+ * ``https://``
+ * ``file://``
+
+.. _deploy_to_nbd_modules:
+
+modules
+=======
+This is not supported in the deployment strategy. Modules must be part of the filesystem already.
+
+initrd
+=======
+
+The initrd contains all necessary files, deamons and scripts to
+bring-up the nbd-client and pivot_root to the final rootfs.
+There are a few important aspects:
+
+* The nbdroot filesystem will not be modified prior to the boot.
+  The filesystems are using security labels and this would alternate the fs.
+  The lava test shell needs to be extracted at runtime with transfer_overlay.
+
+.. include:: examples/test-jobs/standard-nbd-netboot-bbb.yaml
+     :code: yaml
+     :start-after: vmlinuz
+     :end-before: nbdroot
+
+.. _deploy_to_nbd_initrd_url:
+
+url
+---
+
+.. topic:: Supported schema
+
+ * ``http://``
+ * ``https://``
+ * ``file://``
+
+nbdroot
+=======
+
+.. include:: examples/test-jobs/standard-nbd-netboot-bbb.yaml
+     :code: yaml
+     :start-after: allow_modify: false
+     :end-before: os: debian
+
+.. _deploy_to_nbd_nbdroot_url:
+
+url
+---
+
+Specifies the URL to download. All downloads are checksummed using ``md5sum``
+and ``sha256sum``
+
+URLs are checked during the test job validation to ensure that the file can be
+downloaded. Missing files will cause the test job to end as Incomplete.
+
+URLs **must** use one of the supported schemes, the first element of the URL.
+
+.. topic:: Supported schema
+
+ * ``http://``
+ * ``https://``
+ * ``file://``
+
+.. _deploy_to_nbd_nfsroot_compression:
+
+compression
+-----------
+
+The NBD filesystem image is unpacked into a temporary directory onto the dispatcher in a
+location supported by NBD server. The compression method **must** be specified
+so that the filesystem can be unpacked.
+
+.. topic:: Allowed values
+
+ * ``none``
+ * ``gz``
+ * ``bz2``
+ * ``xz``
+
+md5sum (optional)
+^^^^^^
+
+The checksum of the file to download can be provided, and if so it will be
+checked against the downloaded content. This can help to detect multiple
+potential problems such as misconfigured caching or corrupted downloads. If
+compression is used, the checksum to specify is the checksum of the compressed
+file, irrespective of whether that file is decompressed later.
+
+.. _deploy_to_tmpfs_images_sha256sum:
+
+sha256sum (optional)
+^^^^^^^^^
+
+The checksum of the file to download can be provided, and if so it will be
+checked against the downloaded content. This can help to detect multiple
+potential problems such as misconfigured caching or corrupted downloads. If
+compression is used, the checksum to specify is the checksum of the compressed
+file, irrespective of whether that file is decompressed later.:
+

--- a/doc/v2/actions-deploy.rst
+++ b/doc/v2/actions-deploy.rst
@@ -60,4 +60,5 @@ Parameter List
 .. include:: actions-deploy-to-sata.rsti
 .. include:: actions-deploy-to-ssh.rsti
 .. include:: actions-deploy-to-tftp.rsti
+.. include:: actions-deploy-to-nbd.rsti
 .. include:: actions-deploy-to-usb.rsti

--- a/doc/v2/examples/test-jobs/standard-nbd-netboot-bbb.yaml
+++ b/doc/v2/examples/test-jobs/standard-nbd-netboot-bbb.yaml
@@ -1,0 +1,59 @@
+device_type: beaglebone-black
+
+# NBD root deployment
+
+job_name: standard Debian ARMMP nbd test on bbb
+timeouts:
+  job:
+    minutes: 10
+  action:
+    minutes: 5
+  connection:
+    minutes: 2
+priority: medium
+visibility: public
+
+metadata:
+  source: https://git.linaro.org/lava-team/refactoring.git
+  path: standard/standard-nbd-netboot-bbb.yaml
+  build-readme: http://fix.me
+  build-console: https://fix.me
+  build-script: http://fix.me
+
+actions:
+- deploy:
+    timeout:
+      minutes: 4
+    to: nbd
+    kernel:
+      url: http://snapshots.linaro.org/components/lava/standard/debian/jessie/armhf/1/vmlinuz
+    initrd:
+      url: http://fix.me/initramfs-netboot-image-raspberrypi3.ext4.gz.u-boot
+      allow_modify: false
+    nbdroot:
+      url: http://fix.me/rootfs.ext4.xz
+      compression: xz
+    os: debian
+    dtb:
+      url: http://snapshots.linaro.org/components/lava/standard/debian/jessie/armhf/1/dtbs/am335x-boneblack.dtb
+
+- boot:
+    method: u-boot
+    commands: nbd
+    type: bootz
+    auto_login:
+      login_prompt: 'login:'
+      username: root
+    prompts:
+    - 'root@jessie:'
+    timeout:
+      minutes: 2
+
+- test:
+    timeout:
+      minutes: 5
+    definitions:
+    - repository: git://git.linaro.org/qa/test-definitions.git
+      from: git
+      path: ubuntu/smoke-tests-basic.yaml
+      name: smoke-tests

--- a/lava_scheduler_app/schema.py
+++ b/lava_scheduler_app/schema.py
@@ -39,6 +39,7 @@ def _deploy_tftp_schema():
         Optional('kernel'): {Required('url'): str},
         Optional('ramdisk'): {Required('url'): str},
         Optional('nbdroot'): {Required('url'): str},
+        Optional('initrd'): {Required('url'): str},
         Optional('nfsrootfs'): {Required('url'): str},
         Optional('dtb'): {Required('url'): str},
         Optional('modules'): {Required('url'): str},
@@ -242,7 +243,8 @@ def _job_protocols_schema():
                 }
             }
         },
-        'lava-lxc': dict
+        'lava-lxc': dict,
+        'lava-xnbd': dict
     })
 
 

--- a/lava_scheduler_app/tests/device-types/base-uboot.jinja2
+++ b/lava_scheduler_app/tests/device-types/base-uboot.jinja2
@@ -31,6 +31,12 @@
 {% set base_uboot_nfs_bootcmd = uboot_nfs_bootcmd|default(
 "          - setenv bootcmd '" + uboot_ipaddr_cmd|default('dhcp') + "; setenv serverip {SERVER_IP}; run loadkernel; run loadinitrd; run nfsargs; " + run_load_fdt + uboot_bootx_cmd|default('{BOOTX}') + "'
           - run bootcmd") -%}
+{% set base_uboot_nbd_bootcmd = (
+"          - setenv loadnbd 'setenv serverip {SERVER_IP}; run loadkernel; run loadfdt; run loadinitrd';
+          - setenv verify no
+          - setenv bootcmd 'dhcp; run loadnbd; printenv; {BOOTX}'
+          - run bootcmd
+") -%}
 
 {% set base_uboot_usb_commands = uboot_usb_commands|default(
 "          - usb start") -%}
@@ -129,6 +135,7 @@ actions:
     methods:
       lxc:
       tftp:
+      nbd:
       ssh:
         options:
 {{ ssh_options }}
@@ -170,6 +177,20 @@ actions:
           - "setenv nfsargs 'setenv bootargs console={{ console_device }},{{ baud_rate }}n8 root=/dev/nfs rw
             {{ base_nfsroot_args }} {{ base_kernel_args }} {{ base_ip_args }}'"
 {{ base_uboot_nfs_bootcmd }}
+        nbd:
+          commands:
+{{ base_uboot_commands }}
+{% if base_high_limits %}
+{{ base_uboot_high_limits }}
+{% endif %}
+{{ base_uboot_addr_commands }}
+{{ base_uboot_tftp_commands }}
+          # Always quote the entire string if the command includes a colon to support correct YAML.
+          - "setenv nbdbasekargs verbose console={{ console_device }},{{ baud_rate }}n8"
+          - setenv nbdkbootargs '{{ base_nbdroot_args }} rw {{ base_kernel_args }} {{ base_ip_args }}'
+          - setenv nbdextraargs "earlyprintk systemd.log_color=false ${extraargs}"
+          - setenv bootargs "${nbdbasekargs} ${nbdkbootargs} ${nbdextraargs}"
+{{ base_uboot_nbd_bootcmd }}
         ramdisk:
           commands:
 {% if uboot_needs_usb %}

--- a/lava_scheduler_app/tests/device-types/base.jinja2
+++ b/lava_scheduler_app/tests/device-types/base.jinja2
@@ -3,6 +3,7 @@
 {% set base_extra_nfsroot_args = extra_nfsroot_args | default('') %}
 
 {% set base_nfsroot_args = ("nfsroot={NFS_SERVER_IP}:{NFSROOTFS},tcp,hard,intr" + base_extra_nfsroot_args) -%}
+{% set base_nbdroot_args = (" ip=dhcp nbd.server={NBDSERVERIP} nbd.port={NBDSERVERPORT} root=/dev/ram0 ramdisk_size=16384 rootdelay=7 ") -%}
 {% set base_ip_args = base_ip_args|default("ip=dhcp") %}
 {# these options are used by both ssh and scp! #}
 {# check the manpages *carefully* & ensure compatibility! #}

--- a/lava_scheduler_app/tests/device-types/bcm2837-rpi-3-b.jinja2
+++ b/lava_scheduler_app/tests/device-types/bcm2837-rpi-3-b.jinja2
@@ -6,6 +6,10 @@
 {% set booti_ramdisk_addr = '0x04000000' %}
 {% set booti_dtb_addr = '0x00000100' %}
 
+{% set bootm_kernel_addr = '0x01000000' %}
+{% set bootm_ramdisk_addr = '0x04000000' %}
+{% set bootm_dtb_addr = '0x00000100' %}
+
 {% set uboot_mkimage_arch = 'arm64' %}
 
 {% set uboot_needs_usb = true %}


### PR DESCRIPTION
Backport from upstream https://review.linaro.org/#/c/16975/ .

This is the companion to
https://review.linaro.org/#/c/17088/

We include these changes:
- Add a new protocol called 'lava-xnbd' to the schema.
  This will be used to expose a filesystem image via nbd
  (network block device, xnbd-server) to the DUT.
  This is required when the target uses extended filesystem
  attributes which are not supported through nfs.
- Add the initrd parameter.
  In contrast to the 'ramdisk' which is usually a cpio.gz,
  an 'initrd' is a full filesystem image e.g. ext4.
  This is needed when the system uses xattr e.g. for
  security labels also in the 'initrd' already.
  The 'initrd' needs to stay unmodified.
- Add documentation.

v2: squash into one and add documentation

Change-Id: Ib031d9beed6ed25fa262eeb4b9be5ca7cb793112
Signed-off-by: Jan-Simon Möller <dl9pf@gmx.de>